### PR TITLE
AF-48 update pension thank you page list with correct markup

### DIFF
--- a/app/views/ThankYouPensionView.scala.html
+++ b/app/views/ThankYouPensionView.scala.html
@@ -43,19 +43,19 @@
 
     <ul class="govuk-list" id="nav-bar">
         @appConfig.pensionSideBarOneUrl.map { pensionSideBarOneUrl =>
-            @p(link(link = pensionSideBarOneUrl, attrTarget = true, messageKey = "thankYou.pension.sideBar.linkOne"))
+            <li class="govuk-!-margin-bottom-3">@link(link = pensionSideBarOneUrl, attrTarget = true, messageKey = "thankYou.pension.sideBar.linkOne")</li>
         }
         @appConfig.pensionSideBarTwoUrl.map { pensionSideBarTwoUrl =>
-            @p(link(link = pensionSideBarTwoUrl, attrTarget = true, messageKey = "thankYou.pension.sideBar.linkTwo"))
+            <li class="govuk-!-margin-bottom-3">@link(link = pensionSideBarTwoUrl, attrTarget = true, messageKey = "thankYou.pension.sideBar.linkTwo")</li>
         }
         @appConfig.pensionSideBarThreeUrl.map { pensionSideBarThreeUrl =>
-            @p(link(link = pensionSideBarThreeUrl, attrTarget = true, messageKey = "thankYou.pension.sideBar.linkThree"))
+            <li class="govuk-!-margin-bottom-3">@link(link = pensionSideBarThreeUrl, attrTarget = true, messageKey = "thankYou.pension.sideBar.linkThree")</li>
         }
         @appConfig.pensionSideBarFourUrl.map { pensionSideBarFourUrl =>
-            @p(link(link = pensionSideBarFourUrl, attrTarget = true, messageKey = "thankYou.pension.sideBar.linkFour"))
+            <li class="govuk-!-margin-bottom-3">@link(link = pensionSideBarFourUrl, attrTarget = true, messageKey = "thankYou.pension.sideBar.linkFour")</li>
         }
         @appConfig.pensionSideBarFiveUrl.map { pensionSideBarFiveUrl =>
-            @p(link(link = pensionSideBarFiveUrl, attrTarget = true, messageKey = "thankYou.pension.sideBar.linkFive"))
+            <li class="govuk-!-margin-bottom-3">@link(link = pensionSideBarFiveUrl, attrTarget = true, messageKey = "thankYou.pension.sideBar.linkFive")</li>
         }
     </ul>
 


### PR DESCRIPTION
I have used classes on the li's to replicate similar spacing between the links which helps users with poor motor skills and others who are dyslexic for example

## Before
![before](https://user-images.githubusercontent.com/1692222/126508991-8af1c03a-3dc7-4fa6-81da-5cf44c6e9286.png)

## After
![after](https://user-images.githubusercontent.com/1692222/126509010-21162a22-7407-438d-b545-28b8167db541.png)
