### PR TITLE
AF-51 Update InputTextArea.scala.html to use HMRC character count

### DIFF
--- a/app/views/components/InputTextArea.scala.html
+++ b/app/views/components/InputTextArea.scala.html
@@ -45,7 +45,7 @@
 }
 
 @if(maxCharacters.isDefined) {
-    @HmrcCharacterCount(CharacterCount(
+    @hmrcCharacterCount(CharacterCount(
         id = id,
         name = name,
         maxLength = maxCharacters,

--- a/app/views/components/InputTextArea.scala.html
+++ b/app/views/components/InputTextArea.scala.html
@@ -15,11 +15,11 @@
  *@
 
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Content
-@import uk.gov.hmrc.govukfrontend.views.html.components.CharacterCount
+@import uk.gov.hmrc.hmrcfrontend.views.viewmodels.charactercount.CharacterCount
 
 @this(
     govukTextArea: GovukTextarea,
-    govukCharacterCount: GovukCharacterCount
+    hmrcCharacterCount: HmrcCharacterCount
 )
 
 @(
@@ -45,7 +45,7 @@
 }
 
 @if(maxCharacters.isDefined) {
-    @govukCharacterCount(CharacterCount(
+    @HmrcCharacterCount(CharacterCount(
         id = id,
         name = name,
         maxLength = maxCharacters,


### PR DESCRIPTION
The HMRC copy of the GOV.UK component includes the Welsh translations for "You have X characters remaining" and "You have X characters too many"

## Before
<img width="678" alt="Screenshot 2021-07-29 at 17 11 55" src="https://user-images.githubusercontent.com/1692222/127527525-4cd4fef1-4b16-4265-84f4-e1f7921a5cc0.png">
<img width="670" alt="Screenshot 2021-07-29 at 17 12 03" src="https://user-images.githubusercontent.com/1692222/127527528-5bd4623a-ba14-4ad0-b203-c88fcfd34490.png">

## After
<img width="693" alt="Screenshot 2021-07-29 at 17 11 17" src="https://user-images.githubusercontent.com/1692222/127527580-f43a7746-7205-493c-a10c-3a9f7a1120a6.png">
<img width="692" alt="Screenshot 2021-07-29 at 17 11 31" src="https://user-images.githubusercontent.com/1692222/127527584-385a6256-850f-49ed-95f0-18add13d0836.png">
