### PR TITLE
AF-64 Update 100 character limit input error message with improved content

### DIFF
--- a/app/views/GiveReasonView.scala.html
+++ b/app/views/GiveReasonView.scala.html
@@ -54,8 +54,7 @@
                     label = Label(content = Text(messages("giveReason.other.reason.label"))),
                     hint = Some(Hint(content = Text(messages("generic.max-characters", 100)))),
                     errorMessage = form("reason").error.map(err => ErrorMessage(content = Text(messages(err.message, err.args:_*)))),
-                    classes = "govuk-!-width-one-third",
-                    attributes = Map("maxlength" -> "100")))
+                    classes = "govuk-!-width-one-third"))
             )
         )
 

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -306,7 +306,7 @@ giveReason.p800Wrong = Mae fy llythyr cyfrifiad P800 yn anghywir
 giveReason.payOwedTax = Talu’r dreth sydd arnaf
 giveReason.progressChasing = Dilyn hynt rhywbeth
 giveReason.other = Arall, rhowch fanylion
-giveReason.error.maxlength = Rhaid i ‘Pam gwnaethoch roi’r sgôr hon?’ fod yn 1,000 o gymeriadau neu’n llai
+giveReason.error.maxlength = Mae’n rhaid i’ch ateb ar gyfer ‘Yr hyn y daethoch yma i’w wneud’ fod yn 100 o gymeriadau neu lai
 giveReason.other.reason.label = Rhowch wybod i ni yr hyn y daethoch chi yma i’w wneud
 
 giveComments.title = Beth ddaethoch chi yma i’w wneud? - Rhoi adborth - GOV.UK

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -304,7 +304,7 @@ giveReason.p800Wrong = My P800 letter calculation is wrong
 giveReason.payOwedTax = Pay tax I owe
 giveReason.progressChasing = Progress chasing
 giveReason.other = Other, please specify
-giveReason.error.maxlength = Why you gave this score must be 1,000 characters or less
+giveReason.error.maxlength = What you came to do must be 100 characters or less
 giveReason.other.reason.label = Tell us what you came to do
 
 giveComments.title = What did you come to do? - Give feedback - GOV.UK


### PR DESCRIPTION
I have also removed `maxlength="100"` because it is not accessible. This limits the input to 100 characters, but does not announce to a screen reader user that you have reached the limit and would not announce anything if the user copied and pasted into this input.

## Before
![Screenshot 2021-08-16 at 14 59 28](https://user-images.githubusercontent.com/1692222/129730115-4845cd3b-393b-42f7-8cc7-09158e5e7814.png)
![Screenshot 2021-08-16 at 15 00 01](https://user-images.githubusercontent.com/1692222/129730117-bcd66074-99c6-4365-94bd-604a9e2135ce.png)


## After
![Screenshot 2021-08-16 at 14 58 18](https://user-images.githubusercontent.com/1692222/129730195-308eb11d-e9a5-44ea-af40-45649fbf07e5.png)
![Screenshot 2021-08-16 at 14 58 49](https://user-images.githubusercontent.com/1692222/129730203-e6c882e4-deb9-4e33-a0dd-8a48c207fbc7.png)
