### PR TITLE
Update unit tests

### DIFF
--- a/test/controllers/BTAQuestionsControllerSpec.scala
+++ b/test/controllers/BTAQuestionsControllerSpec.scala
@@ -24,6 +24,7 @@ import navigation.FakeNavigator
 import org.mockito.Matchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalacheck.Arbitrary._
+import org.scalacheck.Gen
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
@@ -63,7 +64,8 @@ class BTAQuestionsControllerSpec
   "BTAQuestions Controller" must {
 
     "return OK and the correct view for a GET" in {
-      forAll(arbitrary[Origin]) { origin =>
+      forAll(Gen.alphaStr) { str =>
+        val origin = Origin.fromString(str)
         val result = controller().onPageLoad(origin)(fakeRequest)
 
         status(result) mustBe OK
@@ -72,7 +74,8 @@ class BTAQuestionsControllerSpec
     }
 
     "redirect to the next page when valid data is submitted" in {
-      forAll(arbitrary[Origin]) { origin =>
+      forAll(Gen.alphaStr) { str =>
+        val origin = Origin.fromString(str)
         val result = controller().onSubmit(origin)(fakeRequest)
 
         status(result) mustBe SEE_OTHER
@@ -81,9 +84,9 @@ class BTAQuestionsControllerSpec
     }
 
     "audit response on success" in {
-      forAll(arbitrary[Origin], arbitrary[FeedbackId], arbitrary[BTAQuestions]) { (origin, feedbackId, answers) =>
+      forAll(Gen.alphaStr, arbitrary[FeedbackId], arbitrary[BTAQuestions]) { (originStr, feedbackId, answers) =>
         reset(mockAuditService)
-
+        val origin = Origin.fromString(originStr)
         val values = Map(
           "mainService"       -> answers.mainService.map(_.toString),
           "mainServiceOther"  -> answers.mainServiceOther.map(_.toString),
@@ -105,7 +108,8 @@ class BTAQuestionsControllerSpec
     }
 
     "return a Bad Request and errors when invalid data is submitted" in {
-      forAll(arbitrary[Origin]) { origin =>
+      forAll (Gen.alphaStr) { str =>
+        val origin = Origin.fromString(str)
         val postRequest = fakeRequest
           .withMethod("POST")
           .withFormUrlEncodedBody(("ableToDo", "invalid value"))

--- a/test/controllers/CCGQuestionsControllerSpec.scala
+++ b/test/controllers/CCGQuestionsControllerSpec.scala
@@ -32,6 +32,7 @@ import play.api.mvc.Call
 import play.api.test.Helpers._
 import services.AuditService
 import org.mockito.Matchers.{eq => eqTo, _}
+import org.scalacheck.Gen
 
 class CCGQuestionsControllerSpec extends SpecBase with ScalaCheckPropertyChecks with ModelGenerators with MockitoSugar {
 
@@ -59,7 +60,8 @@ class CCGQuestionsControllerSpec extends SpecBase with ScalaCheckPropertyChecks 
   "CCGQuestions Controller" must {
 
     "return OK and the correct view for a GET" in {
-      forAll(arbitrary[Origin]) { origin =>
+      forAll (Gen.alphaStr) { str =>
+        val origin = Origin.fromString(str)
         val result = controller().onPageLoad(origin)(fakeRequest)
 
         status(result) mustBe OK
@@ -68,7 +70,8 @@ class CCGQuestionsControllerSpec extends SpecBase with ScalaCheckPropertyChecks 
     }
 
     "redirect to the next page when valid data is submitted" in {
-      forAll(arbitrary[Origin]) { origin =>
+      forAll (Gen.alphaStr) { str =>
+        val origin = Origin.fromString(str)
         val result = controller().onSubmit(origin)(fakeRequest)
 
         status(result) mustBe SEE_OTHER
@@ -77,10 +80,10 @@ class CCGQuestionsControllerSpec extends SpecBase with ScalaCheckPropertyChecks 
     }
 
     "audit response on success" in {
-      forAll(arbitrary[Origin], arbitrary[FeedbackId], arbitrary[CCGQuestions], arbitrary[Cid]) {
-        (origin, feedbackId, answers, cid) =>
+      forAll(Gen.alphaStr, arbitrary[FeedbackId], arbitrary[CCGQuestions], arbitrary[Cid]) {
+        (originStr, feedbackId, answers, cid) =>
           reset(mockAuditService)
-
+          val origin = Origin.fromString(originStr)
           val values = Map(
             "complianceCheckUnderstanding" -> answers.complianceCheckUnderstanding.map(_.toString),
             "treatedProfessionally"        -> answers.treatedProfessionally.map(_.toString),
@@ -103,7 +106,8 @@ class CCGQuestionsControllerSpec extends SpecBase with ScalaCheckPropertyChecks 
     }
 
     "return a Bad Request and errors when invalid data is submitted" in {
-      forAll(arbitrary[Origin]) { origin =>
+      forAll (Gen.alphaStr) { str =>
+        val origin = Origin.fromString(str)
         val invalidValue = "*" * 1001
         val postRequest = fakeRequest
           .withMethod("POST")

--- a/test/controllers/ComplaintFeedbackQuestionsControllerSpec.scala
+++ b/test/controllers/ComplaintFeedbackQuestionsControllerSpec.scala
@@ -24,6 +24,7 @@ import navigation.FakeNavigator
 import org.mockito.Matchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalacheck.Arbitrary._
+import org.scalacheck.Gen
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.data.Form
@@ -60,7 +61,8 @@ class ComplaintFeedbackQuestionsControllerSpec extends SpecBase with ScalaCheckP
   "ComplaintFeedbackQuestions Controller" must {
 
     "return OK and the correct view for a GET" in {
-      forAll(arbitrary[Origin]) { origin =>
+      forAll (Gen.alphaStr) { str =>
+        val origin = Origin.fromString(str)
         val result = controller().onPageLoad(origin)(fakeRequest)
 
         status(result) mustBe OK
@@ -69,7 +71,8 @@ class ComplaintFeedbackQuestionsControllerSpec extends SpecBase with ScalaCheckP
     }
 
     "redirect to the next page when valid data is submitted" in {
-      forAll(arbitrary[Origin]) { origin =>
+      forAll (Gen.alphaStr) { str =>
+        val origin = Origin.fromString(str)
         val result = controller().onSubmit(origin)(fakeRequest)
 
         status(result) mustBe SEE_OTHER
@@ -78,10 +81,10 @@ class ComplaintFeedbackQuestionsControllerSpec extends SpecBase with ScalaCheckP
     }
 
     "audit response on success" in {
-      forAll(arbitrary[Origin], arbitrary[FeedbackId], arbitrary[ComplaintFeedbackQuestions], arbitrary[Cid]) {
-        (origin, feedbackId, answers, cid) =>
+      forAll(Gen.alphaStr, arbitrary[FeedbackId], arbitrary[ComplaintFeedbackQuestions], arbitrary[Cid]) {
+        (originStr, feedbackId, answers, cid) =>
           reset(mockAuditService)
-
+          val origin = Origin.fromString(originStr)
           val values = Map(
             "complaintHandledFairly" -> answers.complaintHandledFairly.map(_.toString),
             "howEasyScore" -> answers.howEasyScore.map(_.toString),
@@ -103,7 +106,8 @@ class ComplaintFeedbackQuestionsControllerSpec extends SpecBase with ScalaCheckP
     }
 
     "return a Bad Request and errors when invalid data is submitted" in {
-      forAll(arbitrary[Origin]) { origin =>
+      forAll (Gen.alphaStr) { str =>
+        val origin = Origin.fromString(str)
         val invalidValue = "*" * 1001
         val postRequest = fakeRequest
           .withMethod("POST")

--- a/test/controllers/GiveCommentsControllerSpec.scala
+++ b/test/controllers/GiveCommentsControllerSpec.scala
@@ -24,6 +24,7 @@ import navigation.FakeNavigator
 import org.mockito.Matchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalacheck.Arbitrary._
+import org.scalacheck.Gen
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
@@ -60,7 +61,8 @@ class GiveCommentsControllerSpec
   "GiveComments Controller" must {
 
     "return OK and the correct view for a GET" in {
-      forAll(arbitrary[Origin]) { origin =>
+      forAll (Gen.alphaStr) { str =>
+        val origin = Origin.fromString(str)
         val result = controller().onPageLoad(origin)(fakeRequest)
 
         status(result) mustBe OK
@@ -69,7 +71,8 @@ class GiveCommentsControllerSpec
     }
 
     "redirect to the next page when valid data is submitted" in {
-      forAll(arbitrary[Origin]) { origin =>
+      forAll (Gen.alphaStr) { str =>
+        val origin = Origin.fromString(str)
         val postRequest = fakeRequest
           .withMethod("POST")
           .withFormUrlEncodedBody(("value", "value"))
@@ -81,9 +84,9 @@ class GiveCommentsControllerSpec
     }
 
     "audit response on success" in {
-      forAll(arbitrary[Origin], arbitrary[FeedbackId], arbitrary[String]) { (origin, feedbackId, answer) =>
+      forAll(Gen.alphaStr, arbitrary[FeedbackId], arbitrary[String]) { (originStr, feedbackId, answer) =>
         reset(mockAuditService)
-
+        val origin = Origin.fromString(originStr)
         val values = Map("value" -> answer)
 
         val request = fakeRequest
@@ -97,7 +100,8 @@ class GiveCommentsControllerSpec
     }
 
     "return a Bad Request and errors when invalid data is submitted" in {
-      forAll(arbitrary[Origin]) { origin =>
+      forAll (Gen.alphaStr) { str =>
+        val origin = Origin.fromString(str)
         val invalidValue = "*" * 1001
         val postRequest = fakeRequest
           .withMethod("POST")

--- a/test/controllers/GiveReasonControllerSpec.scala
+++ b/test/controllers/GiveReasonControllerSpec.scala
@@ -25,6 +25,7 @@ import navigation.FakeNavigator
 import org.mockito.Matchers.{any, eq => eqTo}
 import org.mockito.Mockito.{reset, times, verify}
 import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Gen
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.data.Form
@@ -58,7 +59,8 @@ class GiveReasonControllerSpec extends SpecBase with ScalaCheckPropertyChecks wi
 
     "return OK and the correct view for a GET" in {
 
-      forAll { origin: Origin =>
+      forAll (Gen.alphaStr) { str =>
+        val origin = Origin.fromString(str)
         val result = controller().onPageLoad(origin)(fakeRequest)
 
         status(result) mustBe OK
@@ -68,7 +70,8 @@ class GiveReasonControllerSpec extends SpecBase with ScalaCheckPropertyChecks wi
 
     "redirect to the next page when valid data is submitted" in {
 
-      forAll { origin: Origin =>
+      forAll (Gen.alphaStr) { str =>
+        val origin = Origin.fromString(str)
         val postRequest = fakeRequest
           .withMethod("POST")
           .withFormUrlEncodedBody(("value", GiveReason.options(form).head.value.get))
@@ -82,7 +85,8 @@ class GiveReasonControllerSpec extends SpecBase with ScalaCheckPropertyChecks wi
 
     "return a Bad Request and errors when invalid data is submitted" in {
 
-      forAll { origin: Origin =>
+      forAll (Gen.alphaStr) { str =>
+        val origin = Origin.fromString(str)
         val postRequest = fakeRequest
           .withMethod("POST")
           .withFormUrlEncodedBody(("value", "invalid value"))
@@ -96,10 +100,11 @@ class GiveReasonControllerSpec extends SpecBase with ScalaCheckPropertyChecks wi
     }
 
     "audit response on success with reasons besides Other" in {
-      forAll(arbitrary[Origin], arbitrary[FeedbackId], arbitrary[GiveReasonQuestions]) {
-        (origin, feedbackId, answers) =>
+      forAll(Gen.alphaStr, arbitrary[FeedbackId], arbitrary[GiveReasonQuestions]) {
+        (originStr, feedbackId, answers) =>
           reset(mockAuditService)
 
+          val origin = Origin.fromString(originStr)
           val values = Map(
             "value"  -> answers.value.map(_.toString),
             "reason" -> None
@@ -116,10 +121,11 @@ class GiveReasonControllerSpec extends SpecBase with ScalaCheckPropertyChecks wi
     }
 
     "audit response on success with the reason being Other" in {
-      forAll(arbitrary[Origin], arbitrary[FeedbackId], arbitrary[GiveReasonQuestions]) {
-        (origin, feedbackId, answers) =>
+      forAll(Gen.alphaStr, arbitrary[FeedbackId], arbitrary[GiveReasonQuestions]) {
+        (originStr, feedbackId, answers) =>
           reset(mockAuditService)
 
+          val origin = Origin.fromString(originStr)
           val values = Map(
             "value"  -> Some("other"),
             "reason" -> answers.reason

--- a/test/controllers/NmwCcgQuestionsControllerSpec.scala
+++ b/test/controllers/NmwCcgQuestionsControllerSpec.scala
@@ -24,6 +24,7 @@ import navigation.FakeNavigator
 import org.mockito.Matchers.{any, eq => eqTo}
 import org.mockito.Mockito.{reset, times, verify}
 import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Gen
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.data.Form
@@ -58,7 +59,8 @@ class NmwCcgQuestionsControllerSpec
 
     "return OK and the correct view for a GET" in {
 
-      forAll(arbitrary[Origin]) { origin =>
+      forAll (Gen.alphaStr) { str =>
+        val origin = Origin.fromString(str)
         val result = controller.onPageLoad(origin)(fakeRequest)
 
         status(result) mustBe OK
@@ -69,7 +71,8 @@ class NmwCcgQuestionsControllerSpec
 
   "redirect to the next page when valid data is submitted" in {
 
-    forAll(arbitrary[Origin]) { origin =>
+    forAll(Gen.alphaStr) { str =>
+      val origin = Origin.fromString(str)
       val result = controller.onSubmit(origin)(fakeRequest)
 
       status(result) mustBe SEE_OTHER
@@ -79,10 +82,10 @@ class NmwCcgQuestionsControllerSpec
   }
 
   "audit response on success" in {
-    forAll(arbitrary[Origin], arbitrary[FeedbackId], arbitrary[NmwCcgQuestions]) {
-      (origin, feedbackId, answers) =>
+    forAll(Gen.alphaStr, arbitrary[FeedbackId], arbitrary[NmwCcgQuestions]) {
+      (originStr, feedbackId, answers) =>
         reset(mockAuditService)
-
+        val origin = Origin.fromString(originStr)
         val values = Map(
           "treatedProfessionally" -> answers.treatedProfessionally.map(_.toString),
           "checkUnderstanding"    -> answers.checkUnderstanding.map(_.toString),
@@ -102,7 +105,8 @@ class NmwCcgQuestionsControllerSpec
   }
 
   "return a Bad Request and errors when invalid data is submitted" in {
-    forAll(arbitrary[Origin]) { origin =>
+    forAll(Gen.alphaStr) { str =>
+      val origin = Origin.fromString(str)
       val invalidValue = "*" * 1001
       val postRequest = fakeRequest
         .withMethod("POST")

--- a/test/controllers/OtherQuestionsControllerSpec.scala
+++ b/test/controllers/OtherQuestionsControllerSpec.scala
@@ -24,6 +24,7 @@ import navigation.FakeNavigator
 import org.mockito.Matchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalacheck.Arbitrary._
+import org.scalacheck.Gen
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.data.Form
@@ -59,7 +60,8 @@ class OtherQuestionsControllerSpec
   "OtherQuestions Controller" must {
 
     "return OK and the correct view for a GET" in {
-      forAll(arbitrary[Origin]) { origin =>
+      forAll (Gen.alphaStr) { str =>
+        val origin = Origin.fromString(str)
         val result = controller().onPageLoad(origin)(fakeRequest)
 
         status(result) mustBe OK
@@ -68,7 +70,8 @@ class OtherQuestionsControllerSpec
     }
 
     "redirect to the next page when valid data is submitted" in {
-      forAll(arbitrary[Origin]) { origin =>
+      forAll (Gen.alphaStr) { str =>
+        val origin = Origin.fromString(str)
         val result = controller().onSubmit(origin)(fakeRequest)
 
         status(result) mustBe SEE_OTHER
@@ -77,10 +80,10 @@ class OtherQuestionsControllerSpec
     }
 
     "audit response on success" in {
-      forAll(arbitrary[Origin], arbitrary[FeedbackId], arbitrary[OtherQuestions], arbitrary[Cid]) {
-        (origin, feedbackId, answers, cid) =>
+      forAll(Gen.alphaStr, arbitrary[FeedbackId], arbitrary[OtherQuestions], arbitrary[Cid]) {
+        (originStr, feedbackId, answers, cid) =>
           reset(mockAuditService)
-
+          val origin = Origin.fromString(originStr)
           val values = Map(
             "ableToDo"          -> answers.ableToDo.map(_.toString),
             "howEasyScore"      -> answers.howEasyScore.map(_.toString),
@@ -102,7 +105,8 @@ class OtherQuestionsControllerSpec
     }
 
     "return a Bad Request and errors when invalid data is submitted" in {
-      forAll(arbitrary[Origin]) { origin =>
+      forAll (Gen.alphaStr) { str =>
+        val origin = Origin.fromString(str)
         val postRequest = fakeRequest
           .withMethod("POST")
           .withFormUrlEncodedBody(("ableToDo", "invalid value"))

--- a/test/controllers/PTAQuestionsControllerSpec.scala
+++ b/test/controllers/PTAQuestionsControllerSpec.scala
@@ -24,6 +24,7 @@ import navigation.FakeNavigator
 import org.mockito.Matchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalacheck.Arbitrary._
+import org.scalacheck.Gen
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.data.Form
@@ -59,7 +60,8 @@ class PTAQuestionsControllerSpec extends SpecBase with ScalaCheckPropertyChecks 
   "PTAQuestions Controller" must {
 
     "return OK and the correct view for a GET" in {
-      forAll(arbitrary[Origin]) { origin =>
+      forAll (Gen.alphaStr) { str =>
+        val origin = Origin.fromString(str)
         val result = controller().onPageLoad(origin)(fakeRequest)
 
         status(result) mustBe OK
@@ -68,7 +70,8 @@ class PTAQuestionsControllerSpec extends SpecBase with ScalaCheckPropertyChecks 
     }
 
     "redirect to the next page when valid data is submitted" in {
-      forAll(arbitrary[Origin]) { origin =>
+      forAll (Gen.alphaStr) { str =>
+        val origin = Origin.fromString(str)
         val result = controller().onSubmit(origin)(fakeRequest)
 
         status(result) mustBe SEE_OTHER
@@ -77,9 +80,9 @@ class PTAQuestionsControllerSpec extends SpecBase with ScalaCheckPropertyChecks 
     }
 
     "audit response on success" in {
-      forAll(arbitrary[Origin], arbitrary[FeedbackId], arbitrary[PTAQuestions]) { (origin, feedbackId, answers) =>
+      forAll(Gen.alphaStr, arbitrary[FeedbackId], arbitrary[PTAQuestions]) { (originStr, feedbackId, answers) =>
         reset(mockAuditService)
-
+        val origin = Origin.fromString(originStr)
         val values = Map(
           "neededToDo"        -> answers.neededToDo,
           "ableToDo"          -> answers.ableToDo.map(_.toString),
@@ -99,7 +102,8 @@ class PTAQuestionsControllerSpec extends SpecBase with ScalaCheckPropertyChecks 
     }
 
     "return a Bad Request and errors when invalid data is submitted" in {
-      forAll(arbitrary[Origin]) { origin =>
+      forAll (Gen.alphaStr) { str =>
+        val origin = Origin.fromString(str)
         val postRequest = fakeRequest
           .withMethod("POST")
           .withFormUrlEncodedBody(("ableToDo", "invalid value"))

--- a/test/controllers/PensionQuestionsControllerSpec.scala
+++ b/test/controllers/PensionQuestionsControllerSpec.scala
@@ -24,6 +24,7 @@ import navigation.FakeNavigator
 import org.mockito.Matchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalacheck.Arbitrary._
+import org.scalacheck.Gen
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.data.Form
@@ -59,7 +60,8 @@ class PensionQuestionsControllerSpec
   "PensionQuestions Controller" must {
 
     "return OK and the correct view for a GET" in {
-      forAll(arbitrary[Origin]) { origin =>
+      forAll (Gen.alphaStr) { str =>
+        val origin = Origin.fromString(str)
         val result = controller().onPageLoad(origin)(fakeRequest)
 
         status(result) mustBe OK
@@ -68,7 +70,8 @@ class PensionQuestionsControllerSpec
     }
 
     "redirect to the next page when valid data is submitted" in {
-      forAll(arbitrary[Origin]) { origin =>
+      forAll (Gen.alphaStr) { str =>
+        val origin = Origin.fromString(str)
         val result = controller().onSubmit(origin)(fakeRequest)
 
         status(result) mustBe SEE_OTHER
@@ -77,9 +80,9 @@ class PensionQuestionsControllerSpec
     }
 
     "audit response on success" in {
-      forAll(arbitrary[Origin], arbitrary[FeedbackId], arbitrary[PensionQuestions]) { (origin, feedbackId, answers) =>
+      forAll(Gen.alphaStr, arbitrary[FeedbackId], arbitrary[PensionQuestions]) { (originStr, feedbackId, answers) =>
         reset(mockAuditService)
-
+        val origin = Origin.fromString(originStr)
         val values = Map(
           "ableToDo"          -> answers.ableToDo.map(_.toString),
           "howEasyScore"      -> answers.howEasyScore.map(_.toString),
@@ -99,7 +102,8 @@ class PensionQuestionsControllerSpec
     }
 
     "return a Bad Request and errors when invalid data is submitted" in {
-      forAll(arbitrary[Origin]) { origin =>
+      forAll (Gen.alphaStr) { str =>
+        val origin = Origin.fromString(str)
         val postRequest = fakeRequest
           .withMethod("POST")
           .withFormUrlEncodedBody(("ableToDo", "invalid value"))


### PR DESCRIPTION
arbitrary[Origin] creates an origin with invalid characters, replacing with a generator which creates a string containing only readable characters then using that string to create the Origin solves the issue. Verified by running test in debug mode and observing strings containing none latin characters before update and only latin characters after. All test still pass.